### PR TITLE
chore: migrate CRA project to Vite

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="React Minimalist eCommerce Template" />
+    <link rel="manifest" href="/manifest.json" />
+    <title>Flone - React Minimalist eCommerce Template</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "react-modal-video": "^1.2.10",
     "react-redux": "^8.0.4",
     "react-router-dom": "^6.4.3",
-    "react-scripts": "^5.0.1",
     "react-visibility-sensor": "^5.1.1",
     "redux": "^4.2.0",
     "redux-persist": "^6.0.0",
@@ -35,10 +34,9 @@
     "yet-another-react-lightbox": "^2.2.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -59,6 +57,8 @@
   },
   "devDependencies": {
     "redux-devtools-extension": "^2.13.8",
-    "sass": "^1.29.0"
+    "sass": "^1.29.0",
+    "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  define: {
+    'process.env': {
+      PUBLIC_URL: '',
+    },
+  },
+  publicDir: 'public'
+})


### PR DESCRIPTION
## Summary
- switch bundler from `react-scripts` to Vite
- add Vite configuration and root `index.html`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858450c00e883239db64ac197467411